### PR TITLE
Add missing psutil python dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ httpx>=0.25.0
 # Utilities
 python-dotenv>=1.0.0
 pydantic>=2.0.0
+psutil>=7.2.1
 
 # Data processing / visualization
 numpy>=1.24.0


### PR DESCRIPTION
This is my proposed fix to #1. Version 7.2.1 (current) is working fine, but feel free to change the version if you wish.