### PR TITLE
Added downloading of missing embedding model files and automatic subdirectory creation

### DIFF
--- a/admin/routes/models.py
+++ b/admin/routes/models.py
@@ -200,6 +200,9 @@ def _download_embedding_model(model_id: str, progress_callback=None, cancel_chec
 
                 response.raise_for_status()
 
+                # Create any intermediate subdirectories if needed
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+
                 with open(local_path, 'wb') as f:
                     for chunk in response.iter_bytes(chunk_size=8192):
                         f.write(chunk)

--- a/offline_tools/model_registry.py
+++ b/offline_tools/model_registry.py
@@ -22,6 +22,7 @@ AVAILABLE_MODELS = {
         "min_ram_gb": 2,
         "huggingface_repo": "sentence-transformers/all-MiniLM-L6-v2",
         "files": [
+            "1_Pooling/config.json",
             "config.json",
             "tokenizer.json",
             "tokenizer_config.json",
@@ -41,6 +42,7 @@ AVAILABLE_MODELS = {
         "min_ram_gb": 4,
         "huggingface_repo": "sentence-transformers/all-mpnet-base-v2",
         "files": [
+            "1_Pooling/config.json",
             "config.json",
             "tokenizer.json",
             "tokenizer_config.json",
@@ -60,6 +62,7 @@ AVAILABLE_MODELS = {
         "min_ram_gb": 8,
         "huggingface_repo": "intfloat/e5-large-v2",
         "files": [
+            "1_Pooling/config.json",
             "config.json",
             "tokenizer.json",
             "tokenizer_config.json",


### PR DESCRIPTION
This is my proposed solution to #2. The addition to admin/routes/models.py is needed because the files reside in a subdirectory and `httpx.stream` doesn't seem to handle it automatically as far as I know.